### PR TITLE
remove -a for depmod

### DIFF
--- a/connectivity/4GLTE/sim7600g.md
+++ b/connectivity/4GLTE/sim7600g.md
@@ -199,7 +199,7 @@ install:
 
 1. Press `ctrl+x` then `y` then `enter` to save and exit.
 1. `$ sudo make clean && sudo make && sudo install`
-1. `$ sudo depmod -a`
+1. `$ sudo depmod`
 1. `$ sudo modprobe -v simcon_wwan`
 1. Look for `simcon_wwan` in loaded modules list to confirm successful installation: `$ sudo lsmod`
 1. Check kernel messages for successful installation: `$ sudo dmesg`


### PR DESCRIPTION
I had to run without -a, otherwise modprobe couldn't find it.